### PR TITLE
Adding steps for maps & geolocation API enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ https://delorean-demo.firebaseapp.com/
 1. Clone this repository: `git clone https://github.com/neojato/DeLorean-v2.git`.
 1. Run `npm install` from the project root.
 1. Create a new [Firebase project](https://console.firebase.google.com) (if you don't have one already).
+1. Enable Maps JavaScript API and Geocoding API in the [Google Developer Console](https://console.developers.google.com/apis/dashboard) for the Firebase project. Make sure to attach a Billing method to the project as well to make the developer watermark disappear from the map shown on the website (note: your cost will be very minimal or even negligable).
 1. Grab a [Google Maps API Key](https://developers.google.com/maps/documentation/javascript/get-api-key) for your project.
 1. Run `firebase login` and then `firebase init` and link to your Firebase Project.
    * Select Database, Functions, and Hosting


### PR DESCRIPTION
Plus attaching billing method for the project

This PR tries to supplement the docs to avoid issue #36

## Description
If the geolocation API is not enabled besides the Maps API then the lat/lng coordinates won't be populated when the venue street address is set in the site config, and that causes the map to not show on the site's home page.

## Related Issue
#36 

## Motivation and Context
We need to state this explicitly so other's won't open similar tickets after we close #36.

## How Has This Been Tested?
I debugged and tested this with the Valley DevFest 2019 website.

## Screenshots (if appropriate):
Included in the #36